### PR TITLE
replace individuals with the team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 # The sequence matters: later patterns take precedence.
 
 # FILES  OWNERS
-*        @faical-yannick-congo @tkphd
+*        @usnistgov/opensource-team


### PR DESCRIPTION
Rather than individual accounts, route review requests to the full [opensource-team](/usnistgov/teams/opensource-team).